### PR TITLE
テストコード実行時に実行環境を壊してしまう不具合を修正する。

### DIFF
--- a/test/setup
+++ b/test/setup
@@ -1,5 +1,7 @@
 #!/bin/csh -fe
 
+set SVN_OPTION = "--username svn-repo --password svn-repo --config-option servers:global:store-plaintext-passwords=yes"
+
 echo "[setup]: start."
 
 #
@@ -13,21 +15,21 @@ cd repository/svn
 svnadmin create svn-repo > /dev/null
 make start > /dev/null
 
-svn checkout --non-interactive --username=svn-repo --password=svn-repo svn://localhost svn-repo-sample > /dev/null
+svn checkout $SVN_OPTION svn://localhost svn-repo-sample > /dev/null
 cd svn-repo-sample
 mkdir trunk
 svn add trunk > /dev/null
-svn commit --username=svn-repo --password=svn-repo -m "svn の初回コミット。（trunk 作成）" > /dev/null
-svn update --username=svn-repo --password=svn-repo > /dev/null
+svn commit $SVN_OPTION -m "svn の初回コミット。（trunk 作成）" > /dev/null
+svn update $SVN_OPTION > /dev/null
 cd ..
 rm -fr svn-repo-sample
 
-svn checkout --non-interactive --username=svn-repo --password=svn-repo svn://localhost/trunk svn-repo-sample > /dev/null
+svn checkout $SVN_OPTION svn://localhost/trunk svn-repo-sample > /dev/null
 cd svn-repo-sample
 cp -pr ../../../data/svn/* .
 svn add * > /dev/null
-svn commit --username=svn-repo --password=svn-repo -m "svn の二回目コミット。（trunk にテストファイルを追加。）" > /dev/null
-svn update --username=svn-repo --password=svn-repo > /dev/null
+svn commit $SVN_OPTION -m "svn の二回目コミット。（trunk にテストファイルを追加。）" > /dev/null
+svn update $SVN_OPTION > /dev/null
 cd ..
 
 cd ../..
@@ -38,14 +40,16 @@ cd ../..
 
 # before setup
 git --version > /dev/null
-git config --global user.name "Git-SVN Overwrite"
-git config --global user.email "git-svn-overwrite@users"
 
 cd repository/git
 git init --bare git-repo.git > /dev/null
+git config --local user.name "Git-SVN Overwrite"
+git config --local user.email "git-svn-overwrite@users"
 
 git init git-repo-sample > /dev/null
 cd git-repo-sample
+git config --local user.name "Git-SVN Overwrite"
+git config --local user.email "git-svn-overwrite@users"
 git remote add origin ../git-repo.git > /dev/null
 cp -pr ../../../data/git/* .
 git add . > /dev/null

--- a/test/setup
+++ b/test/setup
@@ -8,13 +8,12 @@ echo "[setup]: start."
 
 # before setup
 svn --version > /dev/null
-echo 'store-plaintext-passwords = yes' >> ~/.subversion/servers
 
 cd repository/svn
 svnadmin create svn-repo > /dev/null
 make start > /dev/null
 
-svn checkout --username=svn-repo --password=svn-repo svn://localhost svn-repo-sample > /dev/null
+svn checkout --non-interactive --username=svn-repo --password=svn-repo svn://localhost svn-repo-sample > /dev/null
 cd svn-repo-sample
 mkdir trunk
 svn add trunk > /dev/null

--- a/test/test_git-svn-overwrite
+++ b/test/test_git-svn-overwrite
@@ -1,5 +1,7 @@
 #!/bin/csh -f
 
+set SVN_OPTION = "--username svn-repo --password svn-repo --config-option servers:global:store-plaintext-passwords=yes"
+
 echo "[test/git-svn-overwrite]: start."
 
 set test_datetime = `date +"%Y%m%d%H%M%S"`
@@ -12,7 +14,7 @@ echo "[verify]: start."
 cd repository/git/git-repo-sample
 (git pull origin master > /dev/null) >& /dev/null
 cd ../../svn/svn-repo-sample
-svn update --username=svn-repo --password=svn-repo > /dev/null
+svn update $SVN_OPTION > /dev/null
 cd ../../..
 diff -q -r --exclude=.git --exclude=.svn repository/git/git-repo-sample repository/svn/svn-repo-sample
 if ($status == "0") then
@@ -20,7 +22,7 @@ if ($status == "0") then
   exit 2
 endif
 cd repository/svn/svn-repo-sample
-svn update --username=svn-repo --password=svn-repo > /dev/null
+svn update $SVN_OPTION > /dev/null
 svn log -l 1
 cd ../../..
 echo "[verify]: end."
@@ -37,7 +39,7 @@ echo "[verify]: start."
 cd repository/git/git-repo-sample
 (git pull origin master > /dev/null) >& /dev/null
 cd ../../svn/svn-repo-sample
-svn update --username=svn-repo --password=svn-repo > /dev/null
+svn update $SVN_OPTION > /dev/null
 cd ../../..
 diff -q -r --exclude=.git --exclude=.svn repository/git/git-repo-sample repository/svn/svn-repo-sample
 if ($status != "0") then
@@ -45,7 +47,7 @@ if ($status != "0") then
   exit 2
 endif
 cd repository/svn/svn-repo-sample
-svn update --username=svn-repo --password=svn-repo > /dev/null
+svn update $SVN_OPTION > /dev/null
 svn log -l 1
 cd ../../..
 echo "[verify]: end."
@@ -62,7 +64,7 @@ echo "[verify]: start."
 cd repository/git/git-repo-sample
 (git pull origin master > /dev/null) >& /dev/null
 cd ../../svn/svn-repo-sample
-svn update --username=svn-repo --password=svn-repo > /dev/null
+svn update $SVN_OPTION > /dev/null
 cd ../../..
 diff -q -r --exclude=.git --exclude=.svn repository/git/git-repo-sample repository/svn/svn-repo-sample
 if ($status != "0") then
@@ -70,7 +72,7 @@ if ($status != "0") then
   exit 2
 endif
 cd repository/svn/svn-repo-sample
-svn update --username=svn-repo --password=svn-repo > /dev/null
+svn update $SVN_OPTION > /dev/null
 svn log -l 1
 cd ../../..
 if (-f ./.commit_hash_file) then


### PR DESCRIPTION
## 不具合の内容
- 毎回 setup のたびに無条件で store-plaintext-passwords = yes を ~/.subversion/servers に追記している。
- git config で global の user.name, user.email を無条件に書き換えている。
